### PR TITLE
[OKU-22]Search bar enhancements

### DIFF
--- a/project_app/components/NavBarButtons.js
+++ b/project_app/components/NavBarButtons.js
@@ -24,6 +24,7 @@ const Container = styled.div`
   height: 30px;
   left: 120px;
   top:48px;
+ 
   
   
  Button{

--- a/project_app/components/ToolBar.js
+++ b/project_app/components/ToolBar.js
@@ -32,13 +32,14 @@ const Container = styled.div`
     height: 67px;
     left: 400px;
     top: 150px;
+    color: black;
     background: #ffffff;
     border: 1px solid rgba(0, 0, 0, 0.05);
     box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.15);
     border-radius: 10px;
     font-size: 1.2rem;
     font-family: "Quicksand", sans-serif;
-    padding-left: 100px;
+    padding-left: 40px;
   }
 `;
 

--- a/project_app/components/ToolBar.js
+++ b/project_app/components/ToolBar.js
@@ -10,10 +10,11 @@ function ToolBar() {
           <div
             style={{
               position: "absolute",
-              width: "18.99px",
-              height: "18.73px",
-              top: "170px",
-              left: "980px",
+              width: "28.99px",
+              height: "28.73px",
+              top: "166px",
+              right: "350px",
+              left: "979px",
             }}
           >
             <Image src="/search.png" fill="absolute" alt="image" />

--- a/project_app/components/ToolBar.js
+++ b/project_app/components/ToolBar.js
@@ -1,46 +1,23 @@
-import styled from "styled-components";
 import Image from "next/image";
+import { StyledContainer } from "./styled";
 
 function ToolBar() {
   return (
-    <Container>
-      <div className="search">
-        <div>
-          <input type="text" placeholder="Search board game" />
-          <div
-            style={{
-              position: "absolute",
-              width: "28.99px",
-              height: "28.73px",
-              top: "168px",
-              left: "960px",
-            }}
-          >
-            <Image src="/search.png" fill="absolute" alt="image" />
-          </div>
-        </div>
-      </div>
-    </Container>
+    <div>
+      <StyledContainer>
+        <input type="text" placeholder="Search board game" />
+        <section
+          style={{
+            top: "170px",
+            left: "970px",
+            position: "absolute",
+          }}
+        >
+          <Image src="/search.png" width={18.99} height={18.73} alt="image" />
+        </section>
+      </StyledContainer>
+    </div>
   );
 }
-
-const Container = styled.div`
-  input {
-    box-sizing: border-box;
-    position: absolute;
-    width: 614px;
-    height: 67px;
-    left: 400px;
-    top: 150px;
-    color: black;
-    background: #ffffff;
-    border: 1px solid rgba(0, 0, 0, 0.05);
-    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.15);
-    border-radius: 10px;
-    font-size: 1.2rem;
-    font-family: "Quicksand", sans-serif;
-    padding-left: 40px;
-  }
-`;
 
 export default ToolBar;

--- a/project_app/components/ToolBar.js
+++ b/project_app/components/ToolBar.js
@@ -12,9 +12,8 @@ function ToolBar() {
               position: "absolute",
               width: "28.99px",
               height: "28.73px",
-              top: "166px",
-              right: "350px",
-              left: "979px",
+              top: "168px",
+              left: "960px",
             }}
           >
             <Image src="/search.png" fill="absolute" alt="image" />

--- a/project_app/components/ToolBar.js
+++ b/project_app/components/ToolBar.js
@@ -1,20 +1,16 @@
 import Image from "next/image";
-import { StyledContainer } from "./styled";
+import { StyledContainer, StyledWrapper } from "./styled";
 
 function ToolBar() {
   return (
     <div>
       <StyledContainer>
         <input type="text" placeholder="Search board game" />
-        <section
-          style={{
-            top: "170px",
-            left: "970px",
-            position: "absolute",
-          }}
-        >
-          <Image src="/search.png" width={18.99} height={18.73} alt="image" />
-        </section>
+        <StyledWrapper>
+          <section>
+            <Image src="/search.png" fill="absolute" alt="image" />
+          </section>
+        </StyledWrapper>
       </StyledContainer>
     </div>
   );

--- a/project_app/components/styled.tsx
+++ b/project_app/components/styled.tsx
@@ -138,6 +138,15 @@ export const StyledContainer = styled.div`
 
 `;
 
+export const StyledWrapper = styled.section`
+  position: absolute;
+  top: 176px;
+  width: 18.99px;
+  height: 18.73px;
+  left: 970px;
+`;
+
+
 
 
 

--- a/project_app/components/styled.tsx
+++ b/project_app/components/styled.tsx
@@ -117,3 +117,27 @@ display: block,
 font-weight: 500px,
 box-sizing: border-box,
 `
+
+export const StyledContainer = styled.div`
+  input {
+    box-sizing: border-box;
+    position: absolute;
+    width: 614px;
+    height: 67px;
+    left: 400px;
+    top: 150px;
+    color: black;
+    background: #ffffff;
+    border: 1px solid rgba(0, 0, 0, 0.05);
+    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.15);
+    border-radius: 10px;
+    font-size: 1.2rem;
+    font-family: "Quicksand", sans-serif;
+    padding-left: 40px;
+  }
+
+`;
+
+
+
+


### PR DESCRIPTION
## Summary of changes

- The typed text should be black
- There's too much space on the left

## Change Type
*Put an `x` in all the boxes that apply
- [] Bugfix (non-breaking change which fixes an issue)
- [X] Feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Linear issue link
https://linear.app/oku-no-kumo/issue/OKU-22/search-bar-enhancements



## Wiki link related to this ticket

## Before & after screenshots or video recordings (Before & After)
<img width="1415" alt="Screen Shot 2023-03-08 at 11 08 43 AM" src="https://user-images.githubusercontent.com/34128735/223766819-e3e0e1ac-5424-4b8f-a9dd-f1b2c0244b5b.png">


<img width="772" alt="Screen Shot 2023-03-02 at 9 11 57 AM" src="https://user-images.githubusercontent.com/34128735/222452556-0fcc20d3-dffd-48db-9b28-ef65a3a7579d.png">

<img width="1406" alt="Screen Shot 2023-03-09 at 1 34 03 PM" src="https://user-images.githubusercontent.com/34128735/224122756-09746b72-0aca-4f23-bcc9-c3bd87d76afa.png">
